### PR TITLE
Fix issue setting paid invoice to unpaid

### DIFF
--- a/PluginMollieCallback.php
+++ b/PluginMollieCallback.php
@@ -39,7 +39,7 @@ class PluginMollieCallback extends PluginCallback
         } elseif ($payment->isFailed() || $payment->isExpired() || $payment->isCanceled() || $payment->hasChargebacks()) {
 
             $transaction = "$pluginName payment of $payAmount was not accepted. Original Signup Invoice: $invoiceID (OrderID: " . $transactionId . ")";
-            $cPlugin->PaymentRejected($payAmount, $transaction, $transactionId);
+            $cPlugin->PaymentRejected($transaction);
         } elseif ($payment->hasRefunds()) {
 
             $transaction = "$pluginName payment of $payAmount was refunded. Original Signup Invoice: $invoiceID (OrderID: " . $payment->id . ")";

--- a/PluginMollieCallback.php
+++ b/PluginMollieCallback.php
@@ -39,7 +39,11 @@ class PluginMollieCallback extends PluginCallback
         } elseif ($payment->isFailed() || $payment->isExpired() || $payment->isCanceled() || $payment->hasChargebacks()) {
 
             $transaction = "$pluginName payment of $payAmount was not accepted. Original Signup Invoice: $invoiceID (OrderID: " . $transactionId . ")";
-            $cPlugin->PaymentRejected($transaction);
+            if ($cPlugin->IsUnpaid()) {
+                $cPlugin->PaymentRejected($transaction);
+            } else {
+                $cPlugin->PaymentRejected($transaction, false);
+            }
         } elseif ($payment->hasRefunds()) {
 
             $transaction = "$pluginName payment of $payAmount was refunded. Original Signup Invoice: $invoiceID (OrderID: " . $payment->id . ")";


### PR DESCRIPTION
I've fixed an issue where a paid invoice was incorrectly being set to unpaid when Mollie sent an expired callback. It took some time, but I was able to identify and replicate the error, and I'm happy to report that it is now resolved.